### PR TITLE
Update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,3 +20,5 @@ Contents
 
    usage
    api
+
+Lumache has its documentation hosted on Read the Docs.


### PR DESCRIPTION
(Tutorial Step) Added "Lumache has its documentation hosted on Read the Docs." to the index.rst file.